### PR TITLE
Fixed project URLs for nuget packages.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,8 +17,8 @@
 
 	<PropertyGroup>
 		<Authors>Matthias Gernand</Authors>
-		<RepositoryUrl>https://github.com/fluxera/Fluxera.Guard</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/fluxera/Fluxera.Guard</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/fluxera/Fluxera.Extensions.Hosting.Modules</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/fluxera/Fluxera.Extensions.Hosting.Modules</PackageProjectUrl>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Fix nuget links, eg. under: https://www.nuget.org/packages/Fluxera.Extensions.Hosting.Modules.OpenTelemetry